### PR TITLE
Align optimum-intel based model signature with vLLM signature

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -296,14 +296,14 @@ def patch_model_with_openvino(model, model_config, *model_args, **model_kwargs):
     model._openvino_patch_orig_forward = model.forward
     model.forward = partial(ov_wrapper, model)
 
+from openvino.runtime.utils.node_factory import NodeFactory
+factory = NodeFactory()
 
 def patch_stateful_model(model):
     print('TRANSFORMING OPTIMUM-INTEL MODEL TO vLLM COMPATIBLE FORM')
     from openvino.runtime.passes import Manager, MatcherPass, WrapType, Matcher, AnyInput, Or
     from openvino.runtime import opset13
-    from openvino.runtime.utils.node_factory import NodeFactory
     from openvino.runtime.utils import replace_node
-    factory = NodeFactory()
     factory.add_extension("libuser_ov_extensions.so")
 
     #model.remove_parameter(model.input('beam_idx').get_node())

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -307,17 +307,19 @@ def patch_stateful_model(model):
     factory.add_extension("libuser_ov_extensions.so")
 
     #model.remove_parameter(model.input('beam_idx').get_node())
-    max_context_len = opset13.parameter(shape=[], dtype=np.int32, name='max_context_len')  # max_context_len
+    max_context_len = opset13.parameter(shape=[], dtype=np.int64, name='max_context_len')  # max_context_len
     model_remaining_params = [
         opset13.parameter(shape=[], dtype=bool, name='is_prompt'),  # is_prompt
         opset13.parameter(shape=[-1, -1], dtype=np.int64, name='slot_mapping'),  # slot mapping
         max_context_len,
-        opset13.parameter(shape=[-1], dtype=np.int32, name='context_lens'),  # context_lens
+        opset13.parameter(shape=[-1], dtype=np.int64, name='context_lens'),  # context_lens
         opset13.parameter(shape=[-1, -1], dtype=np.int32, name='block_tables'),  # block_tables
     ]
+    for parameter in model_remaining_params:
+        parameter.get_output_tensor(0).set_names({parameter.get_friendly_name()})
     paged_attention_remaining_args = [
-        opset13.constant([]),  # alibi_slopes
-        opset13.constant(0),  # sliding_window
+        opset13.constant(np.array([], np.float32)),  # alibi_slopes
+        opset13.constant(np.array(0, np.int32)),  # sliding_window
     ]
 
     kv_parameters = []

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -548,7 +548,7 @@ class ModelRunner:
         if is_openvino_optimum_intel:
             import openvino as ov
             from optimum.intel import OVModelForCausalLM
-            self.model = OVModelForCausalLM.from_pretrained(self.model_config.model, export=True, compile=False, load_in_8bit=False) # need stateful because it also enables SDPA
+            self.model = OVModelForCausalLM.from_pretrained(self.model_config.model, export=True, compile=False, load_in_8bit=False, trust_remote_code=True) # need stateful because it also enables SDPA
             patch_stateful_model(self.model.model)
             #ov.serialize(self.model.model, 'vllm_openvino_model.xml')
             core = ov.Core()


### PR DESCRIPTION
- Names for new inputs are set
- The second input name is aligned (`position_ids` instead of `positions` which was an internal name from PT model)
- Types are aligned with original vLLM input types
- Prevent too early unloading of a library with custom op (workaround in Python)